### PR TITLE
perl-5.26.0 compatibility

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,3 +1,4 @@
+use lib '.';
 use inc::Module::Install 1.06;
 use strict;
 use warnings;


### PR DESCRIPTION
Accommodate no '.' by default in @INC.

For:  https://rt.cpan.org/Ticket/Display.html?id=120823