### PR TITLE
Do not replace the literal string '0' with ''

### DIFF
--- a/lib/SQL/Abstract.pm
+++ b/lib/SQL/Abstract.pm
@@ -523,7 +523,7 @@ sub where {
 
   # where ?
   my ($sql, @bind) = $self->_recurse_where($where);
-  $sql = $sql ? $self->_sqlcase(' where ') . "( $sql )" : '';
+  $sql = (defined $sql and length $sql) ? $self->_sqlcase(' where ') . "( $sql )" : '';
 
   # order by?
   if ($order) {

--- a/t/02where.t
+++ b/t/02where.t
@@ -386,6 +386,11 @@ my @handle_tests = (
         stmt  => " WHERE ( (NOT ( c AND (NOT ( (NOT a = ?) AND (NOT b) )) )) ) ",
         bind => [ 1 ],
     },
+    {
+        where => \"0",
+        stmt  => " WHERE ( 0 ) ",
+        bind => [ ],
+    },
 );
 
 for my $case (@handle_tests) {


### PR DESCRIPTION
In Perl, the literal string '0' is false.

Because of this, if one uses the scalar ref \"0", SQL::Abstract considers it a 'false' string and replaces it with an empty string. This patch avoids that, every string that at least one non-whitespache character is used.