### PR TITLE
Do not generate incorrect SQL in presence of -and=>[]

### DIFF
--- a/lib/SQL/Abstract.pm
+++ b/lib/SQL/Abstract.pm
@@ -1484,13 +1484,14 @@ sub _assert_bindval_matches_bindtype {
 sub _join_sql_clauses {
   my ($self, $logic, $clauses_aref, $bind_aref) = @_;
 
-  if (@$clauses_aref > 1) {
+  my @clauses_aref = grep {$_} @$clauses_aref;
+  if (@clauses_aref > 1) {
     my $join  = " " . $self->_sqlcase($logic) . " ";
-    my $sql = '( ' . join($join, @$clauses_aref) . ' )';
+    my $sql = '( ' . join($join, @clauses_aref) . ' )';
     return ($sql, @$bind_aref);
   }
-  elsif (@$clauses_aref) {
-    return ($clauses_aref->[0], @$bind_aref); # no parentheses
+  elsif (@clauses_aref) {
+    return ($clauses_aref[0], @$bind_aref); # no parentheses
   }
   else {
     return (); # if no SQL, ignore @$bind_aref


### PR DESCRIPTION
An empty array ref as value for `-and` can cause incorrect SQL. Example:

```
$ perl -Mv5.12 -MSQL::Abstract -e 'my ($sql,@bind)=SQL::Abstract->new->where({-and=>[],-or=>[a=>1]});say $sql'
Use of uninitialized value in join or string at /usr/share/perl5/SQL/Abstract.pm line 1482.
 WHERE ( (  AND a = ? ) )
```
This is a proposed fix to that bug