### PR TITLE
Fix cpantesters fails

### DIFF
--- a/lib/SQL/Abstract/Plugin/ExtraClauses.pm
+++ b/lib/SQL/Abstract/Plugin/ExtraClauses.pm
@@ -123,7 +123,7 @@ sub _expand_select {
   return $exp unless my $setop = (my $sel = $exp->{-select})->{setop};
   if (my @keys = grep $sel->{$_}, @$before_setop) {
     my %inner; @inner{@keys} = delete @{$sel}{@keys};
-    unshift @{(values(%$setop))[0]{queries}},
+    unshift @{(values(%$setop))[0]->{queries}},
       { -select => \%inner };
   }
   return $exp;

--- a/t/01generate.t
+++ b/t/01generate.t
@@ -886,7 +886,7 @@ for my $t (@tests) {
     }
     else {
       lives_ok(sub {
-        alarm(1); local $SIG{ALRM} = sub {
+        alarm(5); local $SIG{ALRM} = sub {
           no warnings 'redefine';
           my $orig = Carp->can('caller_info');
           local *Carp::caller_info = sub { return if $_[0] > 20; &$orig };

--- a/t/24order_by_chunks.t
+++ b/t/24order_by_chunks.t
@@ -2,11 +2,10 @@ use strict;
 use warnings;
 use Test::More;
 use Test::Exception;
-use Data::Dumper::Concise;
 
 use SQL::Abstract;
 
-use SQL::Abstract::Test import => ['is_same_sql_bind'];
+use SQL::Abstract::Test import => [qw( is_same_sql_bind dumper )];
 my @cases = (
   [
     undef,
@@ -1963,8 +1962,8 @@ for my $case (@cases) {
 
   my @chunks = $sqla->_order_by_chunks($expr);
 
-  unless (is(Dumper(\@chunks), Dumper($out))) {
-    diag("Above failure from expr: ".Dumper($expr));
+  unless (is(dumper(\@chunks), dumper($out))) {
+    diag("Above failure from expr: ".dumper($expr));
   }
 }
 


### PR DESCRIPTION
- Do not use undeclared dep in test, use builtin instead
- Add punctuation to run-on statement not recognized by 5.8