### PR TITLE
Hashref bind values in insert() no longer cause a warning

### DIFF
--- a/lib/SQL/Abstract.pm
+++ b/lib/SQL/Abstract.pm
@@ -330,10 +330,7 @@ sub _insert_value {
       push @all_bind, @bind;
     },
 
-    # THINK: anything useful to do with a HASHREF ?
-    HASHREF => sub {       # (nothing, but old SQLA passed it through)
-      #TODO in SQLA >= 2.0 it will die instead
-      belch "HASH ref as bind value in insert is not supported";
+    HASHREF => sub {
       push @values, '?';
       push @all_bind, $self->_bindtype($column, $v);
     },

--- a/t/01generate.t
+++ b/t/01generate.t
@@ -317,13 +317,12 @@ my @tests = (
               stmt_q => 'SELECT * FROM `test` WHERE ( `a` < to_date(?, \'MM/DD/YY\') AND `b` = ? )',
               bind   => ['02/02/02', 8],
       },
-      { #TODO in SQLA >= 2.0 it will die instead (we kept this just because old SQLA passed it through)
+      {
               func   => 'insert',
               args   => ['test', {a => 1, b => 2, c => 3, d => 4, e => { answer => 42 }}],
               stmt   => 'INSERT INTO test (a, b, c, d, e) VALUES (?, ?, ?, ?, ?)',
               stmt_q => 'INSERT INTO `test` (`a`, `b`, `c`, `d`, `e`) VALUES (?, ?, ?, ?, ?)',
-              bind   => [qw/1 2 3 4/, { answer => 42}],
-              warns  => qr/HASH ref as bind value in insert is not supported/i,
+              bind   => [qw/1 2 3 4/, { answer => 42}]
       },
       {
               func   => 'update',


### PR DESCRIPTION
This is a fairly simple change. When this warning was added [11 years ago](https://github.com/kraih/sql-abstract/commit/5db47f9fe6d06048b35092378a04e3a292d03a19) we didn't know relational databases would be using JSON in 2019. But now we do know there are very valid use cases for hashrefs in bind values. The feature is already used in [Mojo::Pg](https://metacpan.org/pod/Mojo::Pg::Database#insert), and judging by discussions on IRC there are plans to have native support for JSON in `DBD::Pg` at some point in the future. So i believe this deprecation should be reverted.