### PR TITLE
Unbreak Travis build with perl 5.20

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,4 @@ env:
     - COVERAGE="coveralls codecov"
 before_install:
   - eval $(curl https://travis-perl.github.io/init) --auto
+  - cpanm -f Net::SSLeay


### PR DESCRIPTION
Reinstalls Net::SSLeay to sync openssl versions. See failure on line 1354, https://travis-ci.org/dbsrgits/sql-abstract/jobs/615817161#L1354