### PR TITLE
perl 5.8 compatibility

### DIFF
--- a/lib/SQL/Abstract/Plugin/ExtraClauses.pm
+++ b/lib/SQL/Abstract/Plugin/ExtraClauses.pm
@@ -123,7 +123,7 @@ sub _expand_select {
   return $exp unless my $setop = (my $sel = $exp->{-select})->{setop};
   if (my @keys = grep $sel->{$_}, @$before_setop) {
     my %inner; @inner{@keys} = delete @{$sel}{@keys};
-    unshift @{(values(%$setop))[0]{queries}},
+    unshift @{(values(%$setop))[0]->{queries}},
       { -select => \%inner };
   }
   return $exp;


### PR DESCRIPTION
On perl 5.8.9 there is currently a syntax error:

```
t/80extra_clauses.t ....... Useless use of unshift with no values at /Volumes/Vault/david/git-repos/sql-abstract/blib/lib/SQL/Abstract/Plugin/ExtraClauses.pm line 126.
syntax error at /Volumes/Vault/david/git-repos/sql-abstract/blib/lib/SQL/Abstract/Plugin/ExtraClauses.pm line 126, near "]{queries"
syntax error at /Volumes/Vault/david/git-repos/sql-abstract/blib/lib/SQL/Abstract/Plugin/ExtraClauses.pm line 126, near "},"
syntax error at /Volumes/Vault/david/git-repos/sql-abstract/blib/lib/SQL/Abstract/Plugin/ExtraClauses.pm line 128, near "}"
Compilation failed in require at /Volumes/Vault/david/git-repos/sql-abstract/blib/lib/SQL/Abstract.pm line 394.
t/80extra_clauses.t ....... Dubious, test returned 9 (wstat 2304, 0x900)
```

This trivial patch fixes it.