### PR TITLE
Handle empty arrays in -in and -between in subclasses

### DIFF
--- a/lib/SQL/Abstract.pm
+++ b/lib/SQL/Abstract.pm
@@ -1596,6 +1596,8 @@ sub _render_op_between {
         unless $low->{-literal};
       $low;
     } else {
+      puke "Arguments to between must be defined"
+        unless defined $low && defined $high;
       +($low, { -keyword => 'and' }, $high);
     }
   };
@@ -1609,13 +1611,17 @@ sub _render_op_in {
   my ($lhs, @rhs) = @$args;
 
   return $self->join_query_parts(' ',
-    $lhs,
-    { -keyword => $op },
-    $self->join_query_parts(' ',
-      '(',
-      $self->join_query_parts(', ', @rhs),
-      ')'
-    ),
+    @rhs
+      ? (
+          $lhs,
+          { -keyword => $op },
+          $self->join_query_parts(' ',
+            '(',
+            $self->join_query_parts(', ', @rhs),
+            ')'
+          )
+        )
+      : $self->${\($op =~ /^not/ ? 'sqltrue' : 'sqlfalse')}
   );
 }
 


### PR DESCRIPTION
Subclasses that override `_where_field_IN` and `_where_field_BETWEEN` and conditionally re-dispatch to the default handlers in SQL::Abstract were not correctly handling empty array references passed as arguments to `-in`, `-between`, and their negated counterparts.

This behaviour was broken in the refactor that lead to 2.000000, and more specifically in 1.90_03, going from

    $ perl -Ilib -MSQL::Abstract -E '
      say "version " . $SQL::Abstract::VERSION;
      package X {
        use parent "SQL::Abstract";
        use mro "c3";
        sub _where_field_IN { shift->next::method(@_) }
      }
      say X->new->select( table => ["*"], { foo => { -in => [] } } )
    '
    version 1.9002
    SELECT * FROM table WHERE 0=1

to

    $ perl -Ilib -MSQL::Abstract -E '
      say "version " . $SQL::Abstract::VERSION;
      package X {
        use parent "SQL::Abstract";
        use mro "c3";
        sub _where_field_IN { shift->next::method(@_) }
      }
      say X->new->select( table => ["*"], { foo => { -in => [] } } )
    '
    version 1.9003
    SELECT * FROM table WHERE foo IN ( )

and resulting in illegal SQL.

This was breaking behaviour that resulted in downstream issues affecting at least SQL::Abstract::More (see https://github.com/damil/SQL-Abstract-More/issues/20).

Likewise, a class overriding `_where_field_BETWEEN` was not triggering the parameter validation that disallowed empty array references or undefined values to be used as parameters to `-between` and its negation:

    $ perl -Ilib -MSQL::Abstract -E '
      say "version " . $SQL::Abstract::VERSION;
      package X {
        use parent "SQL::Abstract";
        use mro "c3";
        sub _where_field_BETWEEN { shift->next::method(@_) }
      }
      say X->new->select( table => ["*"], { foo => { -between => [] } } )
    '
    version 1.9003
    SELECT * FROM table WHERE ( foo BETWEEN AND )

This change ensures that the path taken by subclasses that override those methods triggers equivalent code paths to those that don't.

Fixes https://rt.cpan.org/Ticket/Display.html?id=142341